### PR TITLE
修复移除文件系统标签的问题

### DIFF
--- a/Assets/GameMain/Scripts/Editor/ResourceRuleEditor/ResourceRuleEditor.cs
+++ b/Assets/GameMain/Scripts/Editor/ResourceRuleEditor/ResourceRuleEditor.cs
@@ -473,6 +473,12 @@ namespace StarForce.Editor.ResourceTools
 
                 if (!HasResource(resourceName, resourceRule.variant))
                 {
+
+                    if (string.IsNullOrEmpty(resourceRule.fileSystem))
+                    {
+                        resourceRule.fileSystem = null;
+                    }
+
                     AddResource(resourceName, resourceRule.variant,resourceRule.fileSystem,
                         resourceRule.loadType, resourceRule.packed,
                         resourceRule.groups.Split(';', ',', '|'));


### PR DESCRIPTION
当文件系统标签一栏为空字符串时会导致添加资源信息失败，生成的xml资源信息为空。